### PR TITLE
Set map_location of torch.load()

### DIFF
--- a/delta_othello/game_mechanics.py
+++ b/delta_othello/game_mechanics.py
@@ -18,7 +18,7 @@ def load_network(team_name: str, network_folder: Path = HERE) -> nn.Module:
     assert (
         net_path.exists()
     ), f"Network saved using TEAM_NAME='{team_name}' doesn't exist! ({net_path})"
-    model = torch.load(net_path)
+    model = torch.load(net_path, map_location=torch.device("cpu"))
     model.eval()
     return model
 


### PR DESCRIPTION
This is an issue because users may train on gpu and torch
serializes it differently based on where the model is trained.
This won't be an issue when the load and save functions are
in the delta_utils repo ;)